### PR TITLE
Raise specific exception when required key or key hash is nil

### DIFF
--- a/lib/rainforest_auth.rb
+++ b/lib/rainforest_auth.rb
@@ -1,5 +1,5 @@
 #
-# Rainforest Authenitcation
+# Rainforest Authentication
 #
 #
 # @author Russell Smith <russ@rainforestqa.com>
@@ -9,6 +9,9 @@ require 'openssl'
 require 'json'
 
 class RainforestAuth
+  class MissingKeyException < StandardError
+  end
+
   attr_reader :key
 
   def initialize(key, key_hash=nil)
@@ -29,11 +32,13 @@ class RainforestAuth
 
   # Return a signature for a callback_type and specified options
   def sign(callback_type, options = nil)
+    raise MissingKeyException, 'Missing key hash' if @key_hash.nil?
     OpenSSL::HMAC.hexdigest(digest, @key_hash, merge_data(callback_type, options))
   end
 
   # Return a signature for a callback_type and specified options
   def sign_old(callback_type, options = nil)
+    raise MissingKeyException, 'Missing key' if @key.nil?
     OpenSSL::HMAC.hexdigest(digest, @key, merge_data(callback_type, options))
   end
 

--- a/spec/rainforest_auth_spec.rb
+++ b/spec/rainforest_auth_spec.rb
@@ -53,6 +53,12 @@ describe RainforestAuth do
     it "works with no options parameter" do
       @auth.sign('test').should == 'd38f897889c808c021a8ed97d2caacdac48b8259'
     end
+
+    context 'key hash is nil' do
+      it 'raises an exception' do
+        expect { RainforestAuth.new(nil).sign('test') }.to raise_error(RainforestAuth::MissingKeyException)
+      end
+    end
   end
 
   #TODO: nuke
@@ -71,6 +77,12 @@ describe RainforestAuth do
 
     it "works with no options parameter" do
       @auth.sign_old('test').should == '0a41bdf26fac08a89573a7f5efe0a5145f2730df'
+    end
+
+    context 'key is nil' do
+      it 'raises an exception' do
+        expect { RainforestAuth.new(nil, 'I am not nil!').sign_old('test') }.to raise_error(RainforestAuth::MissingKeyException)
+      end
     end
   end
 


### PR DESCRIPTION
Current exception is a bit more generic and difficult to debug:
`TypeError: no implicit conversion of nil into String`